### PR TITLE
Enforce node v16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint  --ext .js,.jsx ./",
     "test": "NODE_ENV=test jest"
   },
+  "engines": {
+    "node": "^16.13.1"
+  },
   "resolutions": {
     "node-gyp": "4.0.0"
   },


### PR DESCRIPTION
* add node v16 engine to package.json
* add `.npmrc` to enforce the node version used

🎩 : 
* use a newer version of node (v17)
* run `yarn install` 
* verify the command fails because of an incompatible node version
* use node v16 
* run `yarn install`
* verify the command runs 