### PR TITLE
Makes small updates to account for shopify-cli upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a Node App with Express and React. It is to be used as a starting point 
 
 - [Yarn](https://yarnpkg.com/en/)
 - [Sequelize-cli](https://www.npmjs.com/package/sequelize-cli) installed on your system
-- [Shopify CLI](https://github.com/Shopify/shopify-cli) installed and [configured for local development](https://shopify.dev/apps/tools/cli/getting-started#4-start-a-local-development-server)
+- [Shopify CLI](https://github.com/Shopify/shopify-cli) installed and [configured for local development](https://shopify.dev/apps/tools/cli/getting-started#4-start-a-local-development-server) (version >= 2.16.1)
 
 To set up for first time
 

--- a/app/src/foundation/AppProvider.jsx
+++ b/app/src/foundation/AppProvider.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ExtendedAppProvider} from '@shopify/channels-ui';
-import {Outlet, useLocation} from 'react-router';
+import {Outlet} from 'react-router';
 import polarisTranslations from '@shopify/polaris/locales/en.json';
 import translations from '@shopify/channels-ui/locales/en.json';
 import GraphQLProvider from './GraphQL';
@@ -11,14 +11,12 @@ import '@shopify/channels-ui/dist/styles.css';
 import RoutePropagator from './RoutePropagator';
 
 const AppProvider = () => {
-  const {search} = useLocation();
-
   return (
     <ExtendedAppProvider
       polaris={{i18n: polarisTranslations, linkComponent: Link}}
       i18n={translations}
       config={{
-        host: new URLSearchParams(search).get('host'),
+        host: new URL(location).searchParams.get('host'),
         apiKey: API_KEY,
         forceRedirect: true,
       }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": "^16.13.1"
   },
   "resolutions": {
-    "node-gyp": "4.0.0"
+    "node-gyp": "9.0.0"
   },
   "dependencies": {
     "@apollo/client": "^3.5.6",

--- a/server/index.js
+++ b/server/index.js
@@ -69,7 +69,7 @@ async function startServer() {
 
   addWebhookHandlers();
 
-  app.get('/auth', async (req, res) => {
+  app.get('/login', async (req, res) => {
     const authRoute = await Shopify.Auth.beginAuth(
       req,
       res,
@@ -146,6 +146,7 @@ async function startServer() {
 
   app.listen(process.env.PORT || 3000, function (err) {
     if (err) {
+      console.log(err);
       return console.error(err);
     }
 


### PR DESCRIPTION
Including:
1. new `/login` url rather than `auth`
2. parse proper host in AppProvider
3. upgrade `node-gyp` to 9.0.0


🎩 :
remove `node_modules`
run `yarn install`
run `shopify app serve`
verify the app runs and can navigate around the merchant app