### PR TITLE
adds login|auth regex for url matching to support old vs new cli

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -69,7 +69,8 @@ async function startServer() {
 
   addWebhookHandlers();
 
-  app.get('/login', async (req, res) => {
+  // latest version of shopify-cli uses 'login' route vs old version uses 'auth'
+  app.get('/:type(login|auth)', async (req, res) => {
     const authRoute = await Shopify.Auth.beginAuth(
       req,
       res,


### PR DESCRIPTION
adds support for old vs new shopify-cli url generator.

The new version of shopify-cli generates a url with `login` vs old version of cli generates url with `auth` - this way login will redirect to app and not show the user a blank screen